### PR TITLE
chore: change session token key

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 export const LOCAL_STORAGE_KEYS = {
-  TOKEN: "token",
+  TOKEN: "sessionToken",
   CONVERSATIONS: "conversations",
   AGREED_TERMS: "agreedTerms",
   WELCOME_PAGE_PROMPT: "welcomePagePrompt",


### PR DESCRIPTION
Change the session token key, to avoid conflict with the token already stored in staging or production. 