### PR TITLE
fix: Model/Message Verification Fails and Metadata Field Missing After Renaming Imported Chat

### DIFF
--- a/src/components/common/dialogs/archived-chats/ArchivedChatsModal.tsx
+++ b/src/components/common/dialogs/archived-chats/ArchivedChatsModal.tsx
@@ -243,7 +243,7 @@ export default function ArchivedChatsModal({ open, onOpenChange }: any) {
                         </TableCell>
 
                         <TableCell className="hidden px-3 py-1 md:table-cell">
-                          {dayjs(chat.metadata.archived_at! * 1000).format(
+                          {dayjs(Number(chat.metadata.archived_at!) * 1000).format(
                             "LLL"
                           )}
                         </TableCell>

--- a/src/components/sidebar/ChatItem.tsx
+++ b/src/components/sidebar/ChatItem.tsx
@@ -37,7 +37,13 @@ const ChatItem = ({ chat, isCurrentChat, isPinned, handleDeleteSuccess }: ChatIt
 
   const confirmRename = () => {
     updateConversation.mutate(
-      { conversationId: chat.id, metadata: { title: renameInput } },
+      {
+        conversationId: chat.id,
+        metadata: {
+          ...chat.metadata,
+          title: renameInput,
+        }
+      },
       {
         onSuccess: () => {
           reloadConversations({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,8 +26,8 @@ export interface ConversationInfo {
   created_at: number;
   metadata: {
     title: string;
-    pinned_at?: number;
-    archived_at?: number;
+    pinned_at?: string;
+    archived_at?: string;
     imported_at?: string;
   };
 }


### PR DESCRIPTION
fix issue that renaming chat clears imported_at

closed #151 