### PR TITLE
Implement Passkey (WebAuthn) login flow and client endpoints

### DIFF
--- a/src/api/auth/client.ts
+++ b/src/api/auth/client.ts
@@ -11,6 +11,30 @@ export interface NearAuthResponse {
   is_new_user: boolean;
 }
 
+export interface PasskeyRequestOptions {
+  challenge: string;
+  timeout?: number;
+  rp_id?: string;
+  allow_credentials?: Array<{
+    id: string;
+    type: PublicKeyCredentialType;
+    transports?: AuthenticatorTransport[];
+  }>;
+  user_verification?: UserVerificationRequirement;
+}
+
+export interface PasskeyAssertionPayload {
+  id: string;
+  raw_id: string;
+  type: PublicKeyCredentialType;
+  response: {
+    client_data_json: string;
+    authenticator_data: string;
+    signature: string;
+    user_handle?: string | null;
+  };
+}
+
 class AuthClient extends ApiClient {
   constructor() {
     super({
@@ -105,6 +129,14 @@ class AuthClient extends ApiClient {
 
   oauth2SignIn(provider: OAuth2Provider) {
     window.location.href = `${this.baseURLV2}/auth/${provider}?frontend_callback=${window.location.origin}`;
+  }
+
+  async getPasskeyChallenge(): Promise<PasskeyRequestOptions> {
+    return this.get("/auth/passkey/options", { apiVersion: "v2" });
+  }
+
+  async verifyPasskey(payload: PasskeyAssertionPayload): Promise<NearAuthResponse> {
+    return this.post("/auth/passkey/verify", payload, { apiVersion: "v2" });
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Add passkey-based WebAuthn sign-in so users can authenticate without a NEAR wallet.
- Support a server-driven WebAuthn flow by fetching a challenge and posting back the assertion for verification.
- Surface the passkey option alongside existing OAuth providers to simplify onboarding and account creation.

### Description
- Added `PasskeyRequestOptions` and `PasskeyAssertionPayload` types and two client methods `getPasskeyChallenge` and `verifyPasskey` to `src/api/auth/client.ts`.
- Implemented `handlePasskeyLogin` in `src/pages/AuthPage.tsx` which requests `navigator.credentials.get`, converts base64url encodings with `base64UrlToBytes`/`bytesToBase64Url`, posts the assertion via `authClient.verifyPasskey`, and calls `completeLogin` on success.
- Added browser support checks and error handling for the passkey flow, and kept existing `handleOAuthLogin` and NEAR flows unchanged.
- Added the Passkey CTA button and helper copy to the Auth page UI and navigate to `APP_ROUTES.HOME` after successful login.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d901c26cc8326a2b6421e7218799c)