### PR TITLE
Improve conversation search dialog matching and loading

### DIFF
--- a/src/components/sidebar/ConversationSearchDialog.tsx
+++ b/src/components/sidebar/ConversationSearchDialog.tsx
@@ -1,0 +1,140 @@
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import Fuse from "fuse.js";
+import type React from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useParams } from "react-router";
+import { useGetConversations } from "@/api/chat/queries/useGetConversations";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { cn } from "@/lib";
+import { DEFAULT_CONVERSATION_TITLE } from "@/lib/constants";
+import { toChatRoute } from "@/pages/routes";
+import type { ConversationInfo } from "@/types";
+
+interface ConversationSearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onNavigate?: () => void;
+}
+
+type ConversationSearchItem = ConversationInfo & { searchTitle: string };
+
+const ConversationSearchDialog: React.FC<ConversationSearchDialogProps> = ({ open, onOpenChange, onNavigate }) => {
+  const { t } = useTranslation("translation", { useSuspense: false });
+  const { data: conversations, isLoading } = useGetConversations();
+  const navigate = useNavigate();
+  const { chatId } = useParams();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [searchValue, setSearchValue] = useState("");
+
+  const searchableConversations = useMemo<ConversationSearchItem[]>(
+    () =>
+      (conversations ?? [])
+        .filter((chat) => !chat.metadata?.archived_at)
+        .map((chat) => ({
+          ...chat,
+          searchTitle: chat.metadata?.title || DEFAULT_CONVERSATION_TITLE,
+        })),
+    [conversations]
+  );
+
+  const sortedConversations = useMemo(() => {
+    const getTimestamp = (chat: ConversationInfo): number => {
+      return chat.metadata?.initial_created_at ? Number(chat.metadata.initial_created_at) : chat.created_at;
+    };
+    return [...searchableConversations].sort((a, b) => getTimestamp(b) - getTimestamp(a));
+  }, [searchableConversations]);
+
+  const filteredConversations = useMemo(() => {
+    const query = searchValue.trim();
+    if (!query) return sortedConversations;
+    const fuse = new Fuse(sortedConversations, {
+      keys: ["searchTitle"],
+      threshold: 0.4,
+      ignoreLocation: true,
+    });
+    return fuse.search(query).map((result) => result.item);
+  }, [searchValue, sortedConversations]);
+
+  const handleStartNewChat = () => {
+    navigate("/");
+    onNavigate?.();
+    onOpenChange(false);
+  };
+
+  const handleOpenChat = (conversationId: string) => {
+    navigate(toChatRoute(conversationId));
+    onNavigate?.();
+    onOpenChange(false);
+  };
+
+  useEffect(() => {
+    if (!open) {
+      setSearchValue("");
+      return;
+    }
+    const timeout = window.setTimeout(() => inputRef.current?.focus(), 0);
+    return () => window.clearTimeout(timeout);
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="font-medium text-lg">{t("Search chats")}</DialogTitle>
+          <DialogDescription className="sr-only">{t("Search through your conversations")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-2 flex w-full items-center space-x-2 rounded-xl border border-muted/40 bg-muted/10 px-2.5 py-1.5">
+          <MagnifyingGlassIcon className="size-4 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            className="w-full bg-transparent py-1 pr-4 text-sm outline-hidden"
+            placeholder={t("Search chats")}
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+          />
+          <span className="rounded-md border border-muted/40 px-1.5 py-0.5 text-[10px] text-muted-foreground">⌘K</span>
+        </div>
+
+        <div className="mt-3 max-h-80 space-y-1 overflow-y-auto">
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full justify-start rounded-xl px-3 py-2 text-left"
+            onClick={handleStartNewChat}
+          >
+            {t("Start new chat")}
+          </Button>
+          {isLoading ? (
+            <div className="rounded-xl border border-dashed border-muted/40 px-3 py-6 text-center text-muted-foreground text-sm">
+              {t("Loading chats")}...
+            </div>
+          ) : filteredConversations.length === 0 ? (
+            <div className="rounded-xl border border-dashed border-muted/40 px-3 py-6 text-center text-muted-foreground text-sm">
+              {t("No chats match your search.")}
+            </div>
+          ) : (
+            filteredConversations.map((chat) => (
+              <Button
+                key={chat.id}
+                type="button"
+                variant="ghost"
+                className={cn(
+                  "w-full justify-start rounded-xl px-3 py-2 text-left",
+                  chat.id === chatId && "bg-muted/30"
+                )}
+                onClick={() => handleOpenChat(chat.id)}
+              >
+                <span className="line-clamp-1">{chat.searchTitle}</span>
+              </Button>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ConversationSearchDialog;

--- a/src/components/sidebar/UserMenu.tsx
+++ b/src/components/sidebar/UserMenu.tsx
@@ -1,4 +1,4 @@
-import { ArchiveBoxIcon, ArrowRightStartOnRectangleIcon, Cog8ToothIcon } from "@heroicons/react/24/outline";
+import { ArchiveBoxIcon, ArrowRightStartOnRectangleIcon, Cog8ToothIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 // import { useNavigate } from "react-router";
@@ -24,7 +24,12 @@ interface DropdownItem {
   className?: string;
 }
 
-const UserMenu: React.FC<{ collapsed?: boolean }> = ({ collapsed = false }) => {
+interface UserMenuProps {
+  collapsed?: boolean;
+  onSearchOpen?: () => void;
+}
+
+const UserMenu: React.FC<UserMenuProps> = ({ collapsed = false, onSearchOpen }) => {
   // const navigate = useNavigate();
   const { t } = useTranslation("translation", { useSuspense: false });
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -37,6 +42,12 @@ const UserMenu: React.FC<{ collapsed?: boolean }> = ({ collapsed = false }) => {
 
   const dropdownItems = useMemo<DropdownItem[]>(() => {
     const items: (DropdownItem | false)[] = [
+      {
+        title: t("Search"),
+        icon: <MagnifyingGlassIcon className="h-5 w-5" />,
+        type: "item",
+        action: () => onSearchOpen?.(),
+      },
       {
         title: t("Settings"),
         icon: <Cog8ToothIcon className="h-5 w-5" />,
@@ -67,7 +78,7 @@ const UserMenu: React.FC<{ collapsed?: boolean }> = ({ collapsed = false }) => {
     ];
 
     return items.filter(Boolean) as DropdownItem[];
-  }, [t, signOut]);
+  }, [t, signOut, onSearchOpen]);
 
   return (
     <>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useNavigate, useParams } from "react-router";
 
@@ -16,6 +16,7 @@ import { useViewStore } from "@/stores/useViewStore";
 import type { ConversationInfo } from "@/types";
 import { Button } from "../ui/button";
 import ChatItem from "./ChatItem";
+import ConversationSearchDialog from "./ConversationSearchDialog";
 import UserMenu from "./UserMenu";
 
 const LeftSidebar: React.FC = () => {
@@ -42,6 +43,7 @@ const LeftSidebar: React.FC = () => {
 
   const [isPinnedOpen, setIsPinnedOpen] = useState(true);
   const [isChatsOpen, setIsChatsOpen] = useState(true);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
 
   const { pinned, unpinned } = useMemo(() => {
     const pinned = (conversations || []).filter((c) => !!c.metadata?.pinned_at && !c.metadata?.archived_at);
@@ -73,6 +75,24 @@ const LeftSidebar: React.FC = () => {
     return Object.entries(grouped)
       .sort(([, chatsA], [, chatsB]) => getTimestamp(chatsB[0]) - getTimestamp(chatsA[0]));
   }, [unpinned]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      if (!(event.metaKey || event.ctrlKey) || key !== "k") return;
+      const target = event.target as HTMLElement | null;
+      const isEditable =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable;
+      if (isEditable) return;
+      event.preventDefault();
+      setIsSearchOpen(true);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <nav className="top-0 left-0 z-50 shrink-0 overflow-x-hidden text-sidebar-foreground text-sm">
@@ -199,9 +219,15 @@ const LeftSidebar: React.FC = () => {
 
         <div className="flex flex-col items-start gap-6">
           <div className="w-full border border-primary border-t opacity-20" />
-          <UserMenu />
+          <UserMenu onSearchOpen={() => setIsSearchOpen(true)} />
         </div>
       </div>
+
+      <ConversationSearchDialog
+        open={isSearchOpen}
+        onOpenChange={setIsSearchOpen}
+        onNavigate={handleMobileNavigation}
+      />
     </nav>
   );
 };


### PR DESCRIPTION
### Motivation
- Make conversation search reliably match unnamed chats by using a fallback title when a conversation has no metadata title.
- Show a loading state in the search dialog while conversations are being fetched to avoid an empty result while data loads.
- Keep the "Start new chat" action prominent in the search UI and ensure searches ignore archived conversations.

### Description
- Compute a `searchTitle` for each conversation using `DEFAULT_CONVERSATION_TITLE` as a fallback and update Fuse to search `searchTitle` instead of `metadata.title`.
- Add a loading indicator when `useGetConversations` is still fetching and render appropriate empty states when there are no matches.
- Add a `ConversationSearchDialog` component mount in the sidebar, wire a `Search` item into `UserMenu` via `onSearchOpen`, and add a global `Cmd/Ctrl+K` handler to open the dialog while ignoring editable fields.
- Introduce a `ConversationSearchItem` type and preserve mobile sidebar closing behavior by using the existing `onNavigate` callback when navigating from the dialog.

### Testing
- Ran the dev server with `pnpm dev --host 0.0.0.0 --port 5173` and the server started successfully.
- Executed a Playwright script that navigated to the running app and triggered `Meta+K` to open the search dialog, which completed and produced a screenshot artifact.
- Verified the UI renders and that search returns results for conversations with fallback titles during the automated run, and no automated test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d8fba11c88326845ac8bce9eae0b7)