### PR TITLE
chore: hide add model button

### DIFF
--- a/src/components/chat/ModelSelector.tsx
+++ b/src/components/chat/ModelSelector.tsx
@@ -165,6 +165,7 @@ export default function ModelSelector() {
     return models.filter((modelId) => !otherSelectedModels.includes(modelId.modelId));
   };
 
+  // TODO: Temporary disabled add model button before we fix the `previous_response_id` issue for multiple models in cloud-api.
   const disabledAdd = true; // selectedModels.length >= models.length || selectedModels.length >= 3;
 
   return (


### PR DESCRIPTION
Hide add button model temporarily before we fix the multi-model response issue in cloud-api.
