### PR TITLE
feat(chat): prompt plan upgrade instead of "failed to respond" for gated models

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useRemoteConfig } from "./api/config/queries/useRemoteConfig";
 import { offlineCache } from "./lib/offlineCache";
 import { useIsOnline } from "./hooks/useIsOnline";
 import { PaymentRequiredDialog } from "./components/common/dialogs/PaymentRequiredDialog";
+import { ModelNotAllowedDialog } from "./components/common/dialogs/ModelNotAllowedDialog";
 
 function App() {
   const { isInitialized, isLoading: isAppLoading } = useAppInitialization();
@@ -82,6 +83,7 @@ function App() {
       <div className="relative h-screen">
         <Toaster />
         <PaymentRequiredDialog />
+        <ModelNotAllowedDialog />
         <Routes>
           {/* Protected routes - require authentication */}
           <Route

--- a/src/api/base-client.ts
+++ b/src/api/base-client.ts
@@ -418,15 +418,17 @@ export class ApiClient {
         // before the backend change ships.
         const isModelNotAllowed =
           response.status === 403 &&
-          (error?.code === "model_not_allowed_in_plan" ||
-            /not available in your plan/i.test(error?.error ?? error?.detail ?? ""));
+          error &&
+          typeof error === "object" &&
+          (error.code === "model_not_allowed_in_plan" ||
+            /not available in your plan/i.test(error.error ?? error.detail ?? ""));
         if (isModelNotAllowed) {
           // Normalize the code so downstream handlers can detect this case
           // with a single check regardless of which signal matched.
           error.code = "model_not_allowed_in_plan";
           eventEmitter.emit("model_not_allowed", {
-            model: (body as { model?: string })?.model ?? error?.model ?? "",
-            plan: error?.plan,
+            model: (body as { model?: string })?.model ?? error.model ?? "",
+            plan: error.plan,
           });
         }
         throw error;
@@ -811,6 +813,14 @@ export class ApiClient {
       console.error(err);
       const errMsg = (err as any)?.detail || err || "An unknown error occurred";
       updateFailedMessage(typeof errMsg === "string" ? errMsg : String(errMsg));
+      // Preserve the gated-model marker through the re-throw so callers can
+      // suppress the generic "failed to respond" toast (ModelNotAllowedDialog
+      // handles this case). `errMsg` would otherwise drop the `code`.
+      if ((err as any)?.code === "model_not_allowed_in_plan") {
+        const gatedError = new Error(typeof errMsg === "string" ? errMsg : String(errMsg));
+        (gatedError as any).code = "model_not_allowed_in_plan";
+        throw gatedError;
+      }
       // biome-ignore lint/suspicious/noExplicitAny: explanation
       throw errMsg;
     }

--- a/src/api/base-client.ts
+++ b/src/api/base-client.ts
@@ -411,6 +411,24 @@ export class ApiClient {
         if (response.status === 402) {
           eventEmitter.emit("payment_required");
         }
+        // The model the user picked is gated behind a higher subscription
+        // plan. Surface a dedicated "upgrade your plan" prompt instead of the
+        // generic "model failed to respond" toast. We key off the stable
+        // backend `code`, falling back to the message text so this still works
+        // before the backend change ships.
+        const isModelNotAllowed =
+          response.status === 403 &&
+          (error?.code === "model_not_allowed_in_plan" ||
+            /not available in your plan/i.test(error?.error ?? error?.detail ?? ""));
+        if (isModelNotAllowed) {
+          // Normalize the code so downstream handlers can detect this case
+          // with a single check regardless of which signal matched.
+          error.code = "model_not_allowed_in_plan";
+          eventEmitter.emit("model_not_allowed", {
+            model: (body as { model?: string })?.model ?? error?.model ?? "",
+            plan: error?.plan,
+          });
+        }
         throw error;
       }
 

--- a/src/api/users/queries/useSubscriptions.ts
+++ b/src/api/users/queries/useSubscriptions.ts
@@ -1,11 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/api/query-keys";
+import { LOCAL_STORAGE_KEYS } from "@/lib/constants";
 import { usersClient } from "../client";
 
 export const useSubscriptions = (includeInactive = false) => {
+  // Only fetch when authenticated. This hook is reached on public routes
+  // (e.g. shared chats) via root-mounted dialogs; firing an authenticated
+  // request there is wasteful and can trip a 401 logout for anonymous users.
+  const hasToken = !!localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN);
   return useQuery({
     queryKey: [...queryKeys.subscriptions.list, includeInactive],
     queryFn: () => usersClient.getSubscriptions(includeInactive),
+    enabled: hasToken,
     staleTime: 1000 * 60 * 5,
     gcTime: 1000 * 60 * 10,
     refetchOnWindowFocus: true,

--- a/src/components/common/dialogs/ModelNotAllowedDialog.tsx
+++ b/src/components/common/dialogs/ModelNotAllowedDialog.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import { AGENT_BILLING_URL, AGENT_HOST, AGENT_URL } from "@/api/constants";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useActiveSubscription } from "@/hooks/useActiveSubscription";
+import { eventEmitter } from "@/lib/event";
+
+export function ModelNotAllowedDialog() {
+  const [open, setOpen] = useState(false);
+  const [model, setModel] = useState<string>("");
+  const { activeSubscription } = useActiveSubscription();
+
+  useEffect(() => {
+    const handleModelNotAllowed = ({ model }: { model: string; plan?: string }) => {
+      setModel(model);
+      setOpen(true);
+    };
+
+    eventEmitter.on("model_not_allowed", handleModelNotAllowed);
+    return () => {
+      eventEmitter.off("model_not_allowed", handleModelNotAllowed);
+    };
+  }, []);
+
+  const handleConfirm = () => {
+    window.open(activeSubscription ? AGENT_BILLING_URL : AGENT_URL, "_blank");
+    setOpen(false);
+  };
+
+  const handleLinkClick = () => {
+    setOpen(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={setOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Upgrade to access this model</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                {model ? (
+                  <>
+                    <span className="font-medium">{model}</span> isn't included in your current plan.
+                  </>
+                ) : (
+                  <>This model isn't included in your current plan.</>
+                )}{" "}
+                {activeSubscription ? (
+                  <>
+                    Upgrade your subscription at{" "}
+                    <a
+                      href={AGENT_BILLING_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:no-underline"
+                      onClick={handleLinkClick}
+                    >
+                      {`${AGENT_HOST}/billing`}
+                    </a>{" "}
+                    to get access.
+                  </>
+                ) : (
+                  <>
+                    Subscribe to a plan at{" "}
+                    <a
+                      href={AGENT_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:no-underline"
+                      onClick={handleLinkClick}
+                    >
+                      {AGENT_HOST}
+                    </a>{" "}
+                    to unlock it.
+                  </>
+                )}
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Close</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm}>
+            {activeSubscription ? "Upgrade Plan" : "Subscribe Now"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/common/dialogs/ModelNotAllowedDialog.tsx
+++ b/src/components/common/dialogs/ModelNotAllowedDialog.tsx
@@ -31,7 +31,11 @@ export function ModelNotAllowedDialog() {
   }, []);
 
   const handleConfirm = () => {
-    window.open(activeSubscription ? AGENT_BILLING_URL : AGENT_URL, "_blank");
+    window.open(
+      activeSubscription ? AGENT_BILLING_URL : AGENT_URL,
+      "_blank",
+      "noopener,noreferrer"
+    );
     setOpen(false);
   };
 

--- a/src/lib/event.ts
+++ b/src/lib/event.ts
@@ -3,6 +3,7 @@ import mitt from 'mitt';
 export type Events = {
   logout: undefined;
   payment_required: undefined;
+  model_not_allowed: { model: string; plan?: string };
 };
 
 const eventEmitter = mitt<Events>();

--- a/src/pages/ChatController.tsx
+++ b/src/pages/ChatController.tsx
@@ -202,7 +202,12 @@ export default function ChatController({ children }: { children?: React.ReactNod
         } catch (error: any) {
           if (error?.name !== "AbortError") {
             console.error("Stream error:", error);
-            toast.error(`Model ${model} failed to respond`);
+            // A gated-model error is handled by ModelNotAllowedDialog (an
+            // "upgrade your plan" prompt), so suppress the misleading generic
+            // "failed to respond" toast in that case.
+            if (error?.code !== "model_not_allowed_in_plan") {
+              toast.error(`Model ${model} failed to respond`);
+            }
 
             updateConversation((draft) => {
               if (!draft.conversation) return draft;


### PR DESCRIPTION
## Problem

Picking a model that isn't in the user's subscription plan shows a misleading **"Model … failed to respond"** toast. The request never reaches inference — chat-api rejects it with `403` because the model isn't in the plan's `allowed_models`. The user should be told to **upgrade their plan**, not that the model is broken.

## Change

- Detect the gated-model rejection in the stream error path (`base-client.ts`): a `403` carrying `code: "model_not_allowed_in_plan"` (with a message-text fallback so it works before the backend ships — see chat-api#301).
- Emit a new `model_not_allowed` event and suppress the generic "failed to respond" toast for this case.
- Add `ModelNotAllowedDialog` — an **"Upgrade to access this model"** prompt mirroring the existing `PaymentRequiredDialog`, with an Upgrade Plan / Subscribe CTA to `agent.near.ai/billing`.

## Backend counterpart

nearai/chat-api#301 adds the `model_not_allowed_in_plan` code. This PR works with or without it (message-text fallback), but the robust path keys off the code.

## Testing

- `pnpm run typecheck` ✅
- `pnpm run build` ✅
- `biome lint` clean on changed files ✅
- Manual: reproduced the original `403 "...not available in your plan 'starter'"` against `private.near.ai/v1/responses` with `deepseek-ai/DeepSeek-V4-Flash`; other models on the plan stream fine.